### PR TITLE
Fixes/tiopaul/uploads out of git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ config/cloudinary.yml
 /doc/features.html
 /doc/specs.html
 /public/cache
+/public/uploads
 /public/stylesheets/compiled
 /public/system/*
 /spec/tmp/*

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,11 +2,17 @@
 
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
-  include Cloudinary::CarrierWave
+  if Rails.env.production?
+  	include Cloudinary::CarrierWave
+	end
 
+  process :resize_to_fill => [400,400]
 
-    process :resize_to_fill => [400,400]
-
+  if Rails.env.development? || Rails.env.test?
+    CarrierWave.configure do |config|
+      config.storage = :file
+    end
+  end
 
 
 


### PR DESCRIPTION
* Remove public/uploads folder from git
* Use local public/uploads folder for images in development or test
